### PR TITLE
chore: ignore go modules without tags

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,5 +5,9 @@
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
+  ],
+  "ignoreDeps": [
+    "github.com/rancher/lasso",
+    "k8s.io/utils"
   ]
 }


### PR DESCRIPTION
I would keep these pinned until the changes are reviewed, plus there's less PR spam.

https://github.com/kubernetes/utils/issues/273